### PR TITLE
Add tests to procNode

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -73,7 +73,7 @@ function processTextBlock(text) {
     } else {
         lastquantity = 0;
         if (text.length < 50) {
-            let quantity = StringToNumber(text);
+            let quantity = parseNumberWithPadding(text);
             lastquantity = quantity;
             skips = 0;
         }
@@ -86,7 +86,7 @@ function processTextBlock(text) {
     return text;
 }
 
-function StringToNumber(text) {
+function parseNumberWithPadding(text) {
     let regex = new RegExp('^(?![a-z])(?:[ \n\t]+)?([\.,0-9]+(?![\/⁄]))?(?:[-\− \u00A0])?([¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]|[0-9]+[\/⁄][0-9]+)?(?:[ \n\t]+)?$', 'ig');
     //console.log("try"+text+"s");
 

--- a/contentscript.js
+++ b/contentscript.js
@@ -9,8 +9,6 @@ var useSpaces;
 var useKelvin;
 var degWithoutFahrenheit;
 var isUK = false;
-var lastquantity = 0;
-var skips = 0;
 var useBold;
 var useBrackets;
 var useMetricOnly;
@@ -42,145 +40,11 @@ function walk(node) {
             }
             break;
         case 3: // Text node
-            node.nodeValue = processTextBlock(node.nodeValue);
+            node.nodeValue = processTextBlock(node.nodeValue, convertTablespoon, convertTeaspoon, convertBracketed, degWithoutFahrenheit, includeImproperSymbols, matchIn, includeQuotes, isUK, useMM, useGiga, useKelvin, useBold, useBrackets, useRounding, useComma, useSpaces);
             break;
         default:
             break;
     }
-}
-
-var foundDegreeSymbol = false;
-function processTextBlock(text) {
-    if (text.startsWith('{') || text.length<1)
-        return text;
-
-    //skipping added for quantity and unit in separate blocks - after the number is found, sometimes next node is just a bunch of whitespace, like in cooking.nytimes, so we try again on the next node
-
-    if (lastquantity !== undefined && lastquantity !== 0 && skips < 2) {
-        text = parseUnitOnly(text, foundDegreeSymbol);
-        if (/^[a-zA-Z°º]+$/g.test(text)) {
-            lastquantity = 0;
-        }
-        else {
-            skips++;
-            if (/[°º]/g.test(text))
-                 foundDegreeSymbol=true;
-            else
-                foundDegreeSymbol=false;
-
-        }
-        //console.log(text);
-    } else {
-        lastquantity = 0;
-        if (text.length < 50) {
-            let quantity = parseNumberWithPadding(text);
-            lastquantity = quantity;
-            skips = 0;
-        }
-    }
-   if ((lastquantity !== undefined && lastquantity !== 0 && skips <= 2) ||
-        /[1-9¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]/g.test(text)) {
-        text = replaceAll(text, convertTablespoon, convertTeaspoon, convertBracketed, degWithoutFahrenheit, includeImproperSymbols, matchIn, includeQuotes, isUK, useMM, useGiga, useKelvin, useBold, useBrackets, useRounding, useComma, useSpaces);
-    }
-
-    return text;
-}
-
-function parseNumberWithPadding(text) {
-    let regex = new RegExp('^(?![a-z])(?:[ \n\t]+)?([\.,0-9]+(?![\/⁄]))?(?:[-\− \u00A0])?([¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]|[0-9]+[\/⁄][0-9]+)?(?:[ \n\t]+)?$', 'ig');
-    //console.log("try"+text+"s");
-
-    let matches;
-
-    while ((matches = regex.exec(text)) !== null) {
-        try {
-            if (matches[1] === undefined && matches[2] === undefined)
-                continue;
-            let imp = matches[1]; //.replace(',','');
-            //console.log("found:"+matches[1]);
-            if (matches[1] !== undefined) {
-                imp = imp.replace(',', '');
-
-                if (/[⁄]/.test(matches[1])) { //improvisation, but otherwise 1⁄2 with register 1 as in
-                    matches[2] = matches[1];
-                    imp = 0;
-                } else {
-                    imp = parseFloat(imp);
-                }
-            }
-            //console.log("imp " + imp);
-            if (isNaN(imp))
-                imp = 0;
-
-            if (matches[2] !== undefined)
-                imp += evaluateFraction(matches[2]);
-            //console.log("imp2 " + imp);
-
-            if (imp === 0 || isNaN(imp)) continue;
-            return imp;
-        } catch {
-            //console.log(err.message);
-        }
-    }
-}
-
-
-function parseUnitOnly(text) {
-    // TODO: this is ugly
-    const fahrenheitConversion = conversions[0];
-    if (fahrenheitConversion !== undefined) {
-        if (degWithoutFahrenheit) {
-            fahrenheitConversion.regexUnit = new RegExp(skipempty + '((°|º|deg(rees)?)[ \u00A0]?(F(ahrenheits?)?)?|[\u2109])' + skipbrackets + regend, 'ig');
-        } else {
-            fahrenheitConversion.regexUnit = new RegExp(skipempty + '((°|º|deg(rees)?)[ \u00A0]?F(ahrenheits?)?|[\u2109])' + skipbrackets + regend, 'ig');
-        }
-    }
-
-    //console.log("now trying " + text);
-    const len = conversions.length;
-    for (let i = 0; i < len; i++) {
-        if (conversions[i].regexUnit === undefined)
-            continue;
-        let matches;
-
-        while ((matches = conversions[i].regexUnit.exec(text)) !== null) {
-            try {
-
-                const metStr = convAndForm(lastquantity, conversions[i], "", isUK, useMM, useGiga, useRounding, useComma, useSpaces, useBold, useBrackets);
-                const fullMatch = matches[0];
-                const insertIndex = matches.index + convertedValueInsertionOffset(fullMatch);
-
-                text = insertAt(text, metStr, insertIndex);
-
-            } catch (err) {
-                //console.log(err.message);
-            }
-        }
-
-    }
-
-    if (foundDegreeSymbol) {
-            if ( text.charAt(0)!=='F')
-                return text;
-
-            if (text.length>=3 && /^F\u200B\u3010|^F[\(][0-9]/.test(text))
-                return text; //it has been already converted
-
-                let met = fahrenheitToCelsius(lastquantity, useKelvin);
-
-                var unit = '°C';
-                if (useKelvin) {
-                    met += 273.15;
-                    unit = 'K';
-                    met = roundNicely(met, useRounding);
-                }
-
-            met = formatNumber(met, useComma, useSpaces);
-            const metStr = formatConvertedValue(met, unit, useBold, useBrackets);
-            text = insertAt(text, metStr, 1);
-
-        }
-    return text;
 }
 
 function FlashMessage() {

--- a/contentscript.js
+++ b/contentscript.js
@@ -42,7 +42,7 @@ function walk(node) {
             }
             break;
         case 3: // Text node
-            procNode(node);
+            node.nodeValue = processTextBlock(node.nodeValue);
             break;
         default:
             break;
@@ -50,12 +50,9 @@ function walk(node) {
 }
 
 var foundDegreeSymbol = false;
-function procNode(textNode) {
-
-    let text = textNode.nodeValue;
-
+function processTextBlock(text) {
     if (text.startsWith('{') || text.length<1)
-        return;
+        return text;
 
     //skipping added for quantity and unit in separate blocks - after the number is found, sometimes next node is just a bunch of whitespace, like in cooking.nytimes, so we try again on the next node
 
@@ -83,8 +80,10 @@ function procNode(textNode) {
     }
    if ((lastquantity !== undefined && lastquantity !== 0 && skips <= 2) ||
         /[1-9¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]/g.test(text)) {
-        textNode.nodeValue = replaceAll(text, convertTablespoon, convertTeaspoon, convertBracketed, degWithoutFahrenheit, includeImproperSymbols, matchIn, includeQuotes, isUK, useMM, useGiga, useKelvin, useBold, useBrackets, useRounding, useComma, useSpaces);
+        text = replaceAll(text, convertTablespoon, convertTeaspoon, convertBracketed, degWithoutFahrenheit, includeImproperSymbols, matchIn, includeQuotes, isUK, useMM, useGiga, useKelvin, useBold, useBrackets, useRounding, useComma, useSpaces);
     }
+
+    return text;
 }
 
 function StringToNumber(text) {

--- a/contentscript.js
+++ b/contentscript.js
@@ -57,7 +57,7 @@ function processTextBlock(text) {
     //skipping added for quantity and unit in separate blocks - after the number is found, sometimes next node is just a bunch of whitespace, like in cooking.nytimes, so we try again on the next node
 
     if (lastquantity !== undefined && lastquantity !== 0 && skips < 2) {
-        text = ParseUnitsOnly(text, foundDegreeSymbol);
+        text = parseUnitOnly(text, foundDegreeSymbol);
         if (/^[a-zA-Z°º]+$/g.test(text)) {
             lastquantity = 0;
         }
@@ -125,7 +125,7 @@ function parseNumberWithPadding(text) {
 }
 
 
-function ParseUnitsOnly(text) {
+function parseUnitOnly(text) {
     // TODO: this is ugly
     const fahrenheitConversion = conversions[0];
     if (fahrenheitConversion !== undefined) {

--- a/lib.js
+++ b/lib.js
@@ -1498,10 +1498,11 @@ var foundDegreeSymbol = false;
  *  @return {string} - A new string with metric units
 */
 function processTextBlock(text, convertTablespoon, convertTeaspoon, convertBracketed, degWithoutFahrenheit, includeImproperSymbols, matchIn, includeQuotes, isUK, useMM, useGiga, useKelvin, useBold, useBrackets, useRounding, useComma, useSpaces) {
-    if (text.startsWith('{') || text.length<1)
+    if (text.startsWith('{') || text.length < 1) {
         return text;
+    }
 
-    //skipping added for quantity and unit in separate blocks - after the number is found, sometimes next node is just a bunch of whitespace, like in cooking.nytimes, so we try again on the next node
+    // skipping added for quantity and unit in separate blocks - after the number is found, sometimes next node is just a bunch of whitespace, like in cooking.nytimes, so we try again on the next node
 
     if (lastquantity !== undefined && lastquantity !== 0 && skips < 2) {
         text = parseUnitOnly(text, degWithoutFahrenheit, isUK, useMM, useGiga, useRounding, useComma, useSpaces, useBold, useBrackets);
@@ -1510,13 +1511,12 @@ function processTextBlock(text, convertTablespoon, convertTeaspoon, convertBrack
         }
         else {
             skips++;
-            if (/[°º]/g.test(text))
-                 foundDegreeSymbol=true;
-            else
+            if (/[°º]/g.test(text)) {
+                foundDegreeSymbol=true;
+            } else {
                 foundDegreeSymbol=false;
-
+            }
         }
-        //console.log(text);
     } else {
         lastquantity = 0;
         if (text.length < 50) {
@@ -1525,8 +1525,7 @@ function processTextBlock(text, convertTablespoon, convertTeaspoon, convertBrack
             skips = 0;
         }
     }
-   if ((lastquantity !== undefined && lastquantity !== 0 && skips <= 2) ||
-        /[1-9¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]/g.test(text)) {
+    if ((lastquantity !== undefined && lastquantity !== 0 && skips <= 2) || /[1-9¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]/g.test(text)) {
         text = replaceAll(text, convertTablespoon, convertTeaspoon, convertBracketed, degWithoutFahrenheit, includeImproperSymbols, matchIn, includeQuotes, isUK, useMM, useGiga, useKelvin, useBold, useBrackets, useRounding, useComma, useSpaces);
     }
 
@@ -1539,39 +1538,34 @@ function processTextBlock(text, convertTablespoon, convertTeaspoon, convertBrack
 */
 function parseNumberWithPadding(text) {
     let regex = new RegExp('^(?![a-z])(?:[ \n\t]+)?([\.,0-9]+(?![\/⁄]))?(?:[-\− \u00A0])?([¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]|[0-9]+[\/⁄][0-9]+)?(?:[ \n\t]+)?$', 'ig');
-    //console.log("try"+text+"s");
 
-    let matches;
-
-    while ((matches = regex.exec(text)) !== null) {
-        try {
-            if (matches[1] === undefined && matches[2] === undefined)
-                continue;
-            let imp = matches[1]; //.replace(',','');
-            //console.log("found:"+matches[1]);
-            if (matches[1] !== undefined) {
-                imp = imp.replace(',', '');
-
-                if (/[⁄]/.test(matches[1])) { //improvisation, but otherwise 1⁄2 with register 1 as in
-                    matches[2] = matches[1];
-                    imp = 0;
-                } else {
-                    imp = parseFloat(imp);
-                }
-            }
-            //console.log("imp " + imp);
-            if (isNaN(imp))
-                imp = 0;
-
-            if (matches[2] !== undefined)
-                imp += evaluateFraction(matches[2]);
-            //console.log("imp2 " + imp);
-
-            if (imp === 0 || isNaN(imp)) continue;
-            return imp;
-        } catch {
-            //console.log(err.message);
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+        if (match[1] === undefined && match[2] === undefined) {
+            continue;
         }
+        let imp = match[1]; //.replace(',','');
+        if (match[1] !== undefined) {
+            imp = imp.replace(',', '');
+            if (/[⁄]/.test(match[1])) { //improvisation, but otherwise 1⁄2 with register 1 as in
+                match[2] = match[1];
+                imp = 0;
+            } else {
+                imp = parseFloat(imp);
+            }
+        }
+        if (isNaN(imp)) {
+            imp = 0;
+        }
+
+        if (match[2] !== undefined) {
+            imp += evaluateFraction(match[2]);
+        }
+
+        if (imp === 0 || isNaN(imp)) {
+            continue;
+        }
+        return imp;
     }
 }
 
@@ -1591,49 +1585,41 @@ function parseUnitOnly(text, degWithoutFahrenheit, isUK, useMM, useGiga, useRoun
     }
 
     //console.log("now trying " + text);
-    const len = conversions.length;
-    for (let i = 0; i < len; i++) {
-        if (conversions[i].regexUnit === undefined)
+    for (const conversion of conversions) {
+        if (conversion.regexUnit === undefined) {
             continue;
-        let matches;
-
-        while ((matches = conversions[i].regexUnit.exec(text)) !== null) {
-            try {
-
-                const metStr = convAndForm(lastquantity, conversions[i], "", isUK, useMM, useGiga, useRounding, useComma, useSpaces, useBold, useBrackets);
-                const fullMatch = matches[0];
-                const insertIndex = matches.index + convertedValueInsertionOffset(fullMatch);
-
-                text = insertAt(text, metStr, insertIndex);
-
-            } catch (err) {
-                //console.log(err.message);
-            }
+        }
+        let match;
+        while ((match = conversion.regexUnit.exec(text)) !== null) {
+            const metStr = convAndForm(lastquantity, conversion, "", isUK, useMM, useGiga, useRounding, useComma, useSpaces, useBold, useBrackets);
+            const fullMatch = match[0];
+            const insertIndex = match.index + convertedValueInsertionOffset(fullMatch);
+            text = insertAt(text, metStr, insertIndex);
         }
 
     }
 
     if (foundDegreeSymbol) {
-            if ( text.charAt(0)!=='F')
-                return text;
-
-            if (text.length>=3 && /^F\u200B\u3010|^F[\(][0-9]/.test(text))
-                return text; //it has been already converted
-
-                let met = fahrenheitToCelsius(lastquantity, useKelvin);
-
-                var unit = '°C';
-                if (useKelvin) {
-                    met += 273.15;
-                    unit = 'K';
-                    met = roundNicely(met, useRounding);
-                }
-
-            met = formatNumber(met, useComma, useSpaces);
-            const metStr = formatConvertedValue(met, unit, useBold, useBrackets);
-            text = insertAt(text, metStr, 1);
-
+        if (text.charAt(0) !== 'F') {
+            return text;
         }
+
+        if (text.length>=3 && /^F\u200B\u3010|^F[\(][0-9]/.test(text)) {
+            return text; //it has been already converted
+        }
+
+        let met = fahrenheitToCelsius(lastquantity, useKelvin);
+        let unit = '°C';
+        if (useKelvin) {
+            met += 273.15;
+            unit = 'K';
+            met = roundNicely(met, useRounding);
+        }
+
+        met = formatNumber(met, useComma, useSpaces);
+        const metStr = formatConvertedValue(met, unit, useBold, useBrackets);
+        text = insertAt(text, metStr, 1);
+    }
     return text;
 }
 

--- a/lib.js
+++ b/lib.js
@@ -1477,6 +1477,26 @@ function replaceAll(text, convertTablespoon, convertTeaspoon, convertBracketed, 
 var lastquantity = 0;
 var skips = 0;
 var foundDegreeSymbol = false;
+/** Replace non-metric units with metric units and handle cross-node cases
+ *  @param {string} text - The original text
+ *  @param {boolean} convertTablespoon - Whether to convert tablespoons
+ *  @param {boolean} convertTeaspoon - Whether to convert teaspoons
+ *  @param {boolean} convertBracketed - Whether values that are in brackets should still be converted
+ *  @param {boolean} degWithoutFahrenheit - Whether to assume that ° means °F, not °C
+ *  @param {boolean} includeImproperSymbols} - Whether to support unofficial symbols for feet and inches
+ *  @param {boolean} matchIn - Whether expressions of the form /\d+ in/ should be converted, e.g. "born in 1948 in…"
+ *  @param {boolean} includeQuotes - Whether single and double quotes should be interpreted as feet and inches
+ *  @param {boolean} isUK - Whether to use imperial units instead of US customary units
+ *  @param {boolean} useMM - Whether millimeters should be preferred over centimeters
+ *  @param {boolean} useGiga - Whether the giga SI prefix should be used when it makes sense
+ *  @param {boolean} useKelvin - Whether the returned value will then be converted to Kelvin
+ *  @param {boolean} useBold - Whether the text should use bold Unicode code-points
+ *  @param {boolean} useBrackets - Whether to use lenticular brackets instead of parentheses
+ *  @param {boolean} useRounding - When true, accept up to 3 % error when rounding; when false, round to 2 decimal places
+ *  @param {boolean} useComma - Whether to use a comma as decimal separator
+ *  @param {boolean} useSpaces - Whether to use spaces as thousand separator
+ *  @return {string} - A new string with metric units
+*/
 function processTextBlock(text, convertTablespoon, convertTeaspoon, convertBracketed, degWithoutFahrenheit, includeImproperSymbols, matchIn, includeQuotes, isUK, useMM, useGiga, useKelvin, useBold, useBrackets, useRounding, useComma, useSpaces) {
     if (text.startsWith('{') || text.length<1)
         return text;
@@ -1513,6 +1533,10 @@ function processTextBlock(text, convertTablespoon, convertTeaspoon, convertBrack
     return text;
 }
 
+/** Parse a number, allows white space before and after the pattern
+ *  @param {string} text - The string containing the number
+ *  @return {number | undefined} - The parsed number in case of success, or undefined otherwise
+*/
 function parseNumberWithPadding(text) {
     let regex = new RegExp('^(?![a-z])(?:[ \n\t]+)?([\.,0-9]+(?![\/⁄]))?(?:[-\− \u00A0])?([¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]|[0-9]+[\/⁄][0-9]+)?(?:[ \n\t]+)?$', 'ig');
     //console.log("try"+text+"s");
@@ -1551,6 +1575,10 @@ function parseNumberWithPadding(text) {
     }
 }
 
+/** Parse a non-metric unit, using lastquantity as the value
+ *  @param {string} text - The string containing the unit
+ *  @return {string} - A new string where the unit has been converted to metric
+*/
 function parseUnitOnly(text, degWithoutFahrenheit, isUK, useMM, useGiga, useRounding, useComma, useSpaces, useBold, useBrackets) {
     // TODO: this is ugly
     const fahrenheitConversion = conversions[0];

--- a/lib.js
+++ b/lib.js
@@ -1637,4 +1637,4 @@ function parseUnitOnly(text, degWithoutFahrenheit, isUK, useMM, useGiga, useRoun
     return text;
 }
 
-module.exports = { conversions, evaluateFraction, stepUpOrDown, insertAt, shouldConvert, fahrenheitToCelsius, roundNicely, formatNumber, convertedValueInsertionOffset, bold, formatConvertedValue, parseNumber, replaceFahrenheit, replaceMaybeKeepLastChar, replaceVolume, replaceSurfaceInInches, replaceSurfaceInFeet, replaceFeetAndInches, convAndForm, setIncludeImproperSymbols, replaceFeetAndInchesSymbol, replacePoundsAndOunces, replaceMilesPerGallon, replaceIkeaSurface, replaceOtherUnits, replaceAll };
+module.exports = { conversions, evaluateFraction, stepUpOrDown, insertAt, shouldConvert, fahrenheitToCelsius, roundNicely, formatNumber, convertedValueInsertionOffset, bold, formatConvertedValue, parseNumber, replaceFahrenheit, replaceMaybeKeepLastChar, replaceVolume, replaceSurfaceInInches, replaceSurfaceInFeet, replaceFeetAndInches, convAndForm, setIncludeImproperSymbols, replaceFeetAndInchesSymbol, replacePoundsAndOunces, replaceMilesPerGallon, replaceIkeaSurface, replaceOtherUnits, replaceAll, processTextBlock };

--- a/test.mjs
+++ b/test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { bold, convAndForm, conversions, evaluateFraction, fahrenheitToCelsius, formatConvertedValue, formatNumber, insertAt, parseNumber, replaceAll, replaceFahrenheit, replaceFeetAndInches, replaceFeetAndInchesSymbol, replaceMaybeKeepLastChar, replaceMilesPerGallon, replaceOtherUnits, replacePoundsAndOunces, replaceSurfaceInFeet, replaceSurfaceInInches, replaceVolume, setIncludeImproperSymbols, roundNicely, shouldConvert, stepUpOrDown, convertedValueInsertionOffset } from './lib.js';
+import { bold, convAndForm, conversions, evaluateFraction, fahrenheitToCelsius, formatConvertedValue, formatNumber, insertAt, parseNumber, processTextBlock, replaceAll, replaceFahrenheit, replaceFeetAndInches, replaceFeetAndInchesSymbol, replaceMaybeKeepLastChar, replaceMilesPerGallon, replaceOtherUnits, replacePoundsAndOunces, replaceSurfaceInFeet, replaceSurfaceInInches, replaceVolume, setIncludeImproperSymbols, roundNicely, shouldConvert, stepUpOrDown, convertedValueInsertionOffset } from './lib.js';
 
 import fs from 'fs';
 
@@ -82,6 +82,31 @@ function testParseNumber() {
     assert.equal(parseNumber('−3.14'), -3.14);
     assert.equal(parseNumber('3.14'), 3.14);
     assert.equal(parseNumber('+3.14'), 3.14);
+}
+
+function testProcessTextBlock() {
+    const tests = [
+        ['1', 'pounds of stuff', 'pounds (450 g)˜ of stuff'],
+        ['1½', 'pounds of stuff', 'pounds of stuff'],
+        ['1 ½', 'pounds of stuff', 'pounds (680 g)˜ of stuff'],
+        ['1', 'in of stuff', 'in of stuff'],
+        ['1½', 'in of stuff', 'in of stuff'],
+        ['1 ½', 'in of stuff', 'in of stuff'],
+        ['1', '" of stuff', '" of stuff'],
+        ['1½', '" of stuff', '" of stuff'],
+        ['1 ½', '" of stuff', '" of stuff'],
+        ['1', 'miles of stuff', 'miles of stuff'],
+        ['1½', 'miles of stuff', 'miles of stuff'],
+        ['1 ½', 'miles of stuff', 'miles of stuff'],
+        ['1', '°F of stuff', '°F (1 °C)˜ of stuff'],
+        ['1½', '°F of stuff', '°F of stuff'],
+        ['1 ½', '°F of stuff', '°F (1.5 °C)˜ of stuff'],
+    ];
+    for (const [text1, text2, converted] of tests) {
+        processTextBlock(text1, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false)
+        const output = processTextBlock(text2, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false)
+        assert.equal(output, converted);
+    }
 }
 
 function testReplaceFahrenheit() {
@@ -260,6 +285,7 @@ function main() {
     testFormatNumber();
     testInsertAt();
     testParseNumber();
+    testProcessTextBlock();
     testReplaceFahrenheit();
     testReplaceFeetAndInches();
     testReplaceFeetAndInchesSymbol();

--- a/test.mjs
+++ b/test.mjs
@@ -85,6 +85,7 @@ function testParseNumber() {
 }
 
 function testProcessTextBlock() {
+    /** @type{ [string, string, string][] } */
     const tests = [
         ['1', 'pounds of stuff', 'pounds (450 g)˜ of stuff'],
         ['1½', 'pounds of stuff', 'pounds of stuff'],


### PR DESCRIPTION
Hello @m1l,

In my [previous PR](https://github.com/m1l/Everything-Metric-Firefox/pull/34), I mostly added typing and tests to the text processing logic. As I commented, I did break the HTML TextNode processing logic at some point, so this PR adds typing and tests to that part. By the way, to run the tests and check the typing, you can do the following:

```
$ sudo apt-get install npm  # or whatever equivalent on your system to install node and npm
$ node test.mjs # runs the tests
$ npm ci # installs TypeScript
$ npx tsc # runs TypeScript
```