### PR TITLE
Optimize DOM traversal

### DIFF
--- a/benchmark
+++ b/benchmark
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+xdotool click 1
+sleep 1
+for _ in $(seq 1 10)
+do
+    xdotool key F5
+    sleep 1
+done
+xdotool click 1

--- a/contentscript.js
+++ b/contentscript.js
@@ -20,30 +20,20 @@ var includeQuotes;
 var isparsing=false;
 var includeImproperSymbols;
 
-function walk(node) {
-    if (hasEditableNode(node)) return;
+const excludedTagsRegex = /^(?:SCRIPT|STYLE|IMG|NOSCRIPT|TEXTAREA|CODE)$/ig;
 
-    let child;
-    let next;
-
-    switch (node.nodeType) {
-        case 1: // Element
-        case 9: // Document
-        case 11: // Document fragment
-            child = node.firstChild;
-            while (child) {
-                next = child.nextSibling;
-                if (/SCRIPT|STYLE|IMG|NOSCRIPT|TEXTAREA|CODE/ig.test(child.nodeName) === false) {
-                    walk(child);
-                }
-                child = next;
-            }
-            break;
-        case 3: // Text node
-            node.nodeValue = processTextBlock(node.nodeValue, convertTablespoon, convertTeaspoon, convertBracketed, degWithoutFahrenheit, includeImproperSymbols, matchIn, includeQuotes, isUK, useMM, useGiga, useKelvin, useBold, useBrackets, useRounding, useComma, useSpaces);
-            break;
-        default:
-            break;
+function walk(root) {
+    const treeWalker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    while (treeWalker.nextNode()) {
+        const node = treeWalker.currentNode;
+        const parentNode = node.parentNode;
+        if (hasEditableNode(parentNode)) {
+            continue;
+        }
+        if (excludedTagsRegex.test(parentNode.nodeName)) {
+            continue;
+        }
+        node.nodeValue = processTextBlock(node.nodeValue, convertTablespoon, convertTeaspoon, convertBracketed, degWithoutFahrenheit, includeImproperSymbols, matchIn, includeQuotes, isUK, useMM, useGiga, useKelvin, useBold, useBrackets, useRounding, useComma, useSpaces);
     }
 }
 

--- a/contentscript.js
+++ b/contentscript.js
@@ -32,19 +32,19 @@ const excludedTextNodesXPathSelectors = [
 ];
 const excludedTextNodesXPathString = excludedTextNodesXPathSelectors.map(selector => '//' + selector + '//text()').join('|');
 const excludedTextNodesXPath = new XPathEvaluator().createExpression(excludedTextNodesXPathString);
-const excludedNodes = [];
+const excludedNodes = new Set();
 
 function updateExcludedNodes() {
     const xPathResult = excludedTextNodesXPath.evaluate(document);
-    excludedNodes.length = 0;
+    excludedNodes.clear();
     let node;
     while (node = xPathResult.iterateNext()) {
-        excludedNodes.push(node);
+        excludedNodes.add(node);
     }
 }
 
 function processTextNode(node) {
-    if (excludedNodes.indexOf(node) != -1) {
+    if (excludedNodes.has(node)) {
         return;
     }
     node.nodeValue = processTextBlock(node.nodeValue, convertTablespoon, convertTeaspoon, convertBracketed, degWithoutFahrenheit, includeImproperSymbols, matchIn, includeQuotes, isUK, useMM, useGiga, useKelvin, useBold, useBrackets, useRounding, useComma, useSpaces);

--- a/contentscript.js
+++ b/contentscript.js
@@ -152,10 +152,10 @@ function hasEditableNode(el) {
     if (el.classList !== undefined && el.classList.contains('notranslate')) {
         return true;
     }
+    if (el.isContentEditable) {
+        return true;
+    }
     if (el.getAttribute !== undefined) {
-        if (el.getAttribute('contenteditable')) {
-            return true;
-        }
         if (el.getAttribute('translate') === 'no') {
             return true;
         }

--- a/contentscript.js
+++ b/contentscript.js
@@ -20,17 +20,27 @@ var includeQuotes;
 var isparsing=false;
 var includeImproperSymbols;
 
-const excludedTagsRegex = /^(?:SCRIPT|STYLE|IMG|NOSCRIPT|TEXTAREA|CODE)$/ig;
+const excludedNodesSelectors = [
+    '[contenteditable]',
+    '[translate=no]',
+    '[role=textbox]',
+    '.notranslate',
+    'code',
+    'style',
+    'script',
+    'textarea',
+];
+
+// produce a single CSS selector that matches all the node corresponding to the
+// filters above, as well as their descendants (not text nodes themselves)
+const excludedNodesSelector = excludedNodesSelectors.map(selector => selector + ',' + selector + ' *').join(',');
 
 function walk(root) {
+    const exludedNodes = Array.from(document.querySelectorAll(excludedNodesSelector));
     const treeWalker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
     while (treeWalker.nextNode()) {
         const node = treeWalker.currentNode;
-        const parentNode = node.parentNode;
-        if (hasEditableNode(parentNode)) {
-            continue;
-        }
-        if (excludedTagsRegex.test(parentNode.nodeName)) {
+        if (exludedNodes.indexOf(node.parentNode) != -1) {
             continue;
         }
         node.nodeValue = processTextBlock(node.nodeValue, convertTablespoon, convertTeaspoon, convertBracketed, degWithoutFahrenheit, includeImproperSymbols, matchIn, includeQuotes, isUK, useMM, useGiga, useKelvin, useBold, useBrackets, useRounding, useComma, useSpaces);

--- a/contentscript.js
+++ b/contentscript.js
@@ -151,35 +151,6 @@ browser.runtime.onMessage.addListener(
     }
 });
 
-function hasParentEditableNode(el) {
-    if (hasEditableNode(el)) return true;
-    while (el.parentNode) {
-        el = el.parentNode;
-
-        if (hasEditableNode(el))
-            return true;
-    }
-    return false;
-}
-
-function hasEditableNode(el) {
-    if (el.classList !== undefined && el.classList.contains('notranslate')) {
-        return true;
-    }
-    if (el.isContentEditable) {
-        return true;
-    }
-    if (el.getAttribute !== undefined) {
-        if (el.getAttribute('translate') === 'no') {
-            return true;
-        }
-        if (el.getAttribute('role') === 'textbox') {
-            return true;
-        }
-    }
-    return false;
-}
-
 function initMO(root) {
 
     MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
@@ -192,8 +163,7 @@ function initMO(root) {
             for (var j = 0; j < mutations[i].addedNodes.length; j++) {
                 //checkNode(mutations[i].addedNodes[j]);
                 //console.log(mutations[i].addedNodes[j]);
-                if (!hasParentEditableNode(mutations[i].addedNodes[j]))
-                    walk(mutations[i].addedNodes[j]);
+                walk(mutations[i].addedNodes[j]);
 
                 //var t1 = performance.now();
                 //nmut++;

--- a/index.html
+++ b/index.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles');
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles';
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles';
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/index.html
+++ b/index.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles
+    <div>
+        contenteditable child: 3 miles
+        <div>
+            contenteditable grandchild: 3 miles
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles
+    <div>
+        translate child=no: 3 miles
+        <div>
+            translate grandchild=no: 3 miles
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles
+    <div>
+        role=textbox child=no: 3 miles
+        <div>
+            role=textbox grandchild=no: 3 miles
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles
+    <div>
+        class=notranslate child: 3 miles
+        <div>
+            class=notranslate grandchild: 3 miles
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles
+    <div>
+        code child: 3 miles
+        <div>
+            code grandchild: 3 miles
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles';
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch

--- a/oracles/convertBracketed.html
+++ b/oracles/convertBracketed.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.83 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.83 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.83 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/convertBracketed.html
+++ b/oracles/convertBracketed.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/convertTablespoon.html
+++ b/oracles/convertTablespoon.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.83 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.83 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.83 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/convertTablespoon.html
+++ b/oracles/convertTablespoon.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/convertTeaspoon.html
+++ b/oracles/convertTeaspoon.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.83 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.83 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.83 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/convertTeaspoon.html
+++ b/oracles/convertTeaspoon.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/default.html
+++ b/oracles/default.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.83 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.83 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.83 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/default.html
+++ b/oracles/default.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/degWithoutFahrenheit.html
+++ b/oracles/degWithoutFahrenheit.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.83 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.83 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.83 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/degWithoutFahrenheit.html
+++ b/oracles/degWithoutFahrenheit.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/includeImproperSymbols.html
+++ b/oracles/includeImproperSymbols.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.83 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.83 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.83 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/includeImproperSymbols.html
+++ b/oracles/includeImproperSymbols.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/includeQuotes+includeImproperSymbols.html
+++ b/oracles/includeQuotes+includeImproperSymbols.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.83 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.83 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.83 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/includeQuotes+includeImproperSymbols.html
+++ b/oracles/includeQuotes+includeImproperSymbols.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/includeQuotes.html
+++ b/oracles/includeQuotes.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.83 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.83 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.83 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/includeQuotes.html
+++ b/oracles/includeQuotes.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/isUK.html
+++ b/oracles/isUK.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.83 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.83 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.83 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/isUK.html
+++ b/oracles/isUK.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/matchIn.html
+++ b/oracles/matchIn.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.83 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.83 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.83 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/matchIn.html
+++ b/oracles/matchIn.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/useBold.html
+++ b/oracles/useBold.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.83 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.83 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.83 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/useBold.html
+++ b/oracles/useBold.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/useBrackets+useBold.html
+++ b/oracles/useBrackets+useBold.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles'​【𝟰.𝟴𝟯 𝗸𝗺】);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles'​【𝟰.𝟴𝟯 𝗸𝗺】;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles'​【𝟰.𝟴𝟯 𝗸𝗺】;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/useBrackets+useBold.html
+++ b/oracles/useBrackets+useBold.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+    <div>
+        contenteditable child: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+        <div>
+            contenteditable grandchild: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+    <div>
+        translate child=no: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+        <div>
+            translate grandchild=no: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+    <div>
+        role=textbox child=no: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+        <div>
+            role=textbox grandchild=no: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+    <div>
+        class=notranslate child: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+        <div>
+            class=notranslate grandchild: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+    <div>
+        code child: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+        <div>
+            code grandchild: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles'​【𝟰.𝟴𝟯 𝗸𝗺】;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles​【𝟰.𝟴𝟯 𝗸𝗺】 is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles​【𝟰.𝟴𝟯 𝗸𝗺】
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch​【𝟭 𝗺】

--- a/oracles/useBrackets.html
+++ b/oracles/useBrackets.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles​【4.83 km】
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles'​【4.83 km】);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles'​【4.83 km】;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles​【4.83 km】
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles'​【4.83 km】;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/useBrackets.html
+++ b/oracles/useBrackets.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles​【4.83 km】
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles​【4.83 km】
+    <div>
+        contenteditable child: 3 miles​【4.83 km】
+        <div>
+            contenteditable grandchild: 3 miles​【4.83 km】
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles​【4.83 km】
+    <div>
+        translate child=no: 3 miles​【4.83 km】
+        <div>
+            translate grandchild=no: 3 miles​【4.83 km】
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles​【4.83 km】
+    <div>
+        role=textbox child=no: 3 miles​【4.83 km】
+        <div>
+            role=textbox grandchild=no: 3 miles​【4.83 km】
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles​【4.83 km】
+    <div>
+        class=notranslate child: 3 miles​【4.83 km】
+        <div>
+            class=notranslate grandchild: 3 miles​【4.83 km】
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles​【4.83 km】
+    <div>
+        code child: 3 miles​【4.83 km】
+        <div>
+            code grandchild: 3 miles​【4.83 km】
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles'​【4.83 km】;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles​【4.83 km】 is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles​【4.83 km】
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch​【1 m】

--- a/oracles/useComma.html
+++ b/oracles/useComma.html
@@ -1,7 +1,99 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>All these should be converted</h3>
+<div>
+    div: 3 miles (4,83 km)˜
+</div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4,83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4,83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4,83 km)˜
+    <div>
+        contenteditable child: 3 miles (4,83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4,83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4,83 km)˜
+    <div>
+        translate child=no: 3 miles (4,83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4,83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4,83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4,83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4,83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4,83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4,83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4,83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4,83 km)˜
+    <div>
+        code child: 3 miles (4,83 km)˜
+        <div>
+            code grandchild: 3 miles (4,83 km)˜
+        </div>
+    </div>
+</code>
+<script id="selfCheckScript">
+const X = '3 miles' (4,83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.getElementById('selfCheckScript');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4,83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4,83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/useGiga.html
+++ b/oracles/useGiga.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.83 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.83 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.83 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/useGiga.html
+++ b/oracles/useGiga.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/useKelvin.html
+++ b/oracles/useKelvin.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.83 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.83 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.83 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/useKelvin.html
+++ b/oracles/useKelvin.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/useMM.html
+++ b/oracles/useMM.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.83 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.83 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.83 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/useMM.html
+++ b/oracles/useMM.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/useRounding.html
+++ b/oracles/useRounding.html
@@ -1,10 +1,27 @@
 <meta charset="utf-8">
 <h1>EverythingMetric test page</h1>
 <h2>DOM tests</h2>
-<h3>This one should be converted</h3>
+<h3>All these should be converted</h3>
 <div>
     div: 3 miles (4.8 km)˜
 </div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.8 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.8 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
 <h3>None of these should be converted</h3>
 <div contenteditable>
     contenteditable: 3 miles (4.8 km)˜
@@ -51,10 +68,10 @@
         </div>
     </div>
 </code>
-<script>
+<script id="selfCheckScript">
 const X = '3 miles' (4.8 km)˜;
 setTimeout(function() {
-    const scriptNode = document.querySelector('script');
+    const scriptNode = document.getElementById('selfCheckScript');
     const scriptText = scriptNode.childNodes[0].textContent;
     // NOTE: the character is in the script, since we are passing it as an
     // argument. But it should not be in the first few characters. That would

--- a/oracles/useRounding.html
+++ b/oracles/useRounding.html
@@ -1,7 +1,82 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>This one should be converted</h3>
+<div>
+    div: 3 miles (4.8 km)˜
+</div>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.8 km)˜
+    <div>
+        contenteditable child: 3 miles (4.8 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.8 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.8 km)˜
+    <div>
+        translate child=no: 3 miles (4.8 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.8 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.8 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.8 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.8 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.8 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.8 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.8 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.8 km)˜
+    <div>
+        code child: 3 miles (4.8 km)˜
+        <div>
+            code grandchild: 3 miles (4.8 km)˜
+        </div>
+    </div>
+</code>
+<script>
+const X = '3 miles' (4.8 km)˜;
+setTimeout(function() {
+    const scriptNode = document.querySelector('script');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.8 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.8 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜

--- a/oracles/useSpaces.html
+++ b/oracles/useSpaces.html
@@ -1,7 +1,99 @@
 <meta charset="utf-8">
+<h1>EverythingMetric test page</h1>
+<h2>DOM tests</h2>
+<h3>All these should be converted</h3>
+<div>
+    div: 3 miles (4.83 km)˜
+</div>
+<div id="textAdded">
+    text added:
+</div>
+<div id="spanAdded">
+    span added:
+</div>
+<script>
+setTimeout(function() {
+    // textNode
+    const textNode = document.createTextNode('delayed: 3 miles' (4.83 km)˜);
+    document.getElementById('textAdded').appendChild(textNode);
+    // span
+    const span = document.createElement('SPAN');
+    span.innerText = 'delayed: 3 miles' (4.83 km)˜;
+    document.getElementById('spanAdded').appendChild(span);
+}, 100);
+</script>
+<h3>None of these should be converted</h3>
+<div contenteditable>
+    contenteditable: 3 miles (4.83 km)˜
+    <div>
+        contenteditable child: 3 miles (4.83 km)˜
+        <div>
+            contenteditable grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div translate="no">
+    translate=no: 3 miles (4.83 km)˜
+    <div>
+        translate child=no: 3 miles (4.83 km)˜
+        <div>
+            translate grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div role="textbox">
+    role=textbox: 3 miles (4.83 km)˜
+    <div>
+        role=textbox child=no: 3 miles (4.83 km)˜
+        <div>
+            role=textbox grandchild=no: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<div class="notranslate someotherclass">
+    class=notranslate: 3 miles (4.83 km)˜
+    <div>
+        class=notranslate child: 3 miles (4.83 km)˜
+        <div>
+            class=notranslate grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</div>
+<code>
+    code: 3 miles (4.83 km)˜
+    <div>
+        code child: 3 miles (4.83 km)˜
+        <div>
+            code grandchild: 3 miles (4.83 km)˜
+        </div>
+    </div>
+</code>
+<script id="selfCheckScript">
+const X = '3 miles' (4.83 km)˜;
+setTimeout(function() {
+    const scriptNode = document.getElementById('selfCheckScript');
+    const scriptText = scriptNode.childNodes[0].textContent;
+    // NOTE: the character is in the script, since we are passing it as an
+    // argument. But it should not be in the first few characters. That would
+    // happen if the values of the X variable was converted.
+    if (scriptText.indexOf('【') < 30) {
+        alert('The contents of the <script> tag were modified!');
+    }
+}, 1000);
+</script>
+<div id="styleTest">
+    style:
+</div>
+<style>
+#styleTest::after {
+    content: '3 miles (4.83 km)˜ is a long distance';
+}
+</style>
+<textarea>
+    textarea: 3 miles (4.83 km)˜
+</textarea>
+<h2>Conversion tests</h2>
 <pre>
-This page is for tesing if the extension is working correctly.
-
 All of these should show 1 m
 
 39.37 inch (1 m)˜


### PR DESCRIPTION
Hi again @m1L!

Following my last comment on #40, I took a look at the DOM traversal logic. It looked like calling `node.nextSibling` was costing a significant amount of time. With some Stack Overflow sleuthing and random keyword googling, I learned that there is actually an API for this: [`TreeWalker`](https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker)! By using `NodeFilter.SHOW_TEXT`, we can quickly select the text nodes.

The issue is that this breaks the filtering on ancestor nodes. We could use the `filter` argument of `TreeWalker`, but this is slow. Or call `hasParentEditableNode`, but this is even slower. So I have used another approach: when starting a traversal, I first list all the nodes that should be excluded, using CSS selectors; then, during the traversal, I check whether the text node's parent is in the exclusion list. It seems to work pretty well.

After doing that, there was a significant amount of time spent on `node.parentNode`. This was needed, since we cannot list text nodes directly from the CSS selectors, so we need to check whether each text node's parent is in the exclusion list. However, I also learned about [`XPathEvaluator`](https://developer.mozilla.org/en-US/docs/Web/API/XPathEvaluator), which is similar to CSS selectors, but allow us to select text nodes directly. I was able to replace CSS selectors and get rid of `node.parentNode`.

However, `XPathEvaluator` is slower than CSS selectors, so both approaches are roughly as efficient. I have kept both commits in the history, so that we can go back to CSS selectors if it turns out they are better.

---

I have also added some (manual) tests to `index.html` for this. The mutation observer should also handle the insertion of text nodes, not just of element nodes.

---

With this, the [Web version of _From the Earth to the Moon_](https://www.gutenberg.org/cache/epub/83/pg83-images.html) goes from taking 174 ms to only 106 ms. The [text version](https://www.gutenberg.org/cache/epub/83/pg83.txt) goes from 298 ms to 279 ms, but I think it might just be noise.

Before:

![image](https://github.com/m1l/Everything-Metric-Firefox/assets/8493765/e7eb4885-4d66-4a16-8965-bbdb2ee18348)

After:

![image](https://github.com/m1l/Everything-Metric-Firefox/assets/8493765/dc09f064-721d-4a5e-adbf-c4d936a24e1d)

Most of the remaining time is spent in `exec(…)` and in the calls to `toLocaleString(…)`. For the first one, merging all the `replace*` functions into one, and using a single pass with a single regular expression should gain us some performance. For the second one, the main point is related to #41.

![image](https://github.com/m1l/Everything-Metric-Firefox/assets/8493765/13e6bad3-a599-4372-8ed4-efa8ce5fc15a)