### PR TITLE
Add support for Firefox Android

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -70,6 +70,7 @@
     "gecko": {
       "id": "{ffd50a6d-1702-4d87-83c3-ec468f67de6a}",
       "strict_min_version": "57.0"
-    }
+    },
+    "gecko_android": {}
   }
 }


### PR DESCRIPTION
This PR marks the extension as compatible with Firefox for Android. 

As per https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#firefox_gecko_properties, providing a `gecko_android` key is needed to make it Android-compatible. To match the min_version with desktop, it should be an empty object.

I have temporarily loaded the currently published addon (from AMO) to Firefox Android and it seems to work flawlessly.

Merging this and updating the AMO listing should fix #47 